### PR TITLE
Feature non import api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,12 @@
-*.falsl
-*.dx64fsl
-.#*
 #*
+*.DS_Store
+*.dx64fsl
+*.falsl
+*.fas
+*.fasl
+*.lx64fsl
+*.~lock*
 *~
+.#*
+\#*\#
 scratchpad.lisp

--- a/easing-single-float.lisp
+++ b/easing-single-float.lisp
@@ -1,6 +1,6 @@
 ;;;; easing.lisp
 
-(in-package #:easing-single-float)
+(in-package #:easing-f)
 
 (defconstant pi-sf 3.141592653589793s0)
 
@@ -15,9 +15,9 @@
 				    x
 				    'single-float))
 			      args))
-	(ease-in (alexandria:symbolicate 'ease-in- name :-f))
-	(ease-out (alexandria:symbolicate 'ease-out- name :-f))
-	(ease-in-out (alexandria:symbolicate 'ease-in-out- name :-f)))
+	(ease-in (alexandria:symbolicate 'in- name))
+	(ease-out (alexandria:symbolicate 'out- name))
+	(ease-in-out (alexandria:symbolicate 'in-out- name)))
     `(progn
        ;; in
        (declaim (inline ,ease-in)
@@ -60,9 +60,9 @@
 
 ;; The float versions
 
-(declaim (inline linear-f)
-         (ftype (function (single-float) single-float) linear-f))
-(defun linear-f (x)
+(declaim (inline linear)
+         (ftype (function (single-float) single-float) linear))
+(defun linear (x)
   (declare (optimize (speed 3) (safety 0) (debug 0))
 	   (single-float x))
   x)

--- a/easing-single-float.lisp
+++ b/easing-single-float.lisp
@@ -1,0 +1,106 @@
+;;;; easing.lisp
+
+(in-package #:easing-single-float)
+
+(defconstant pi-sf 3.141592653589793s0)
+
+(defmacro defeasing-f (name args &body body)
+  (let ((x (or (car args) 'x))
+	(arg-names (remove-if (lambda (x) (char= (aref (symbol-name x) 0) #\&))
+			      (mapcar (lambda (x) (if (listp x) (first x) x))
+				      args)))
+	(declaim-args (mapcar (lambda (x)
+				(if (and (symbolp x)
+					 (char= (aref (symbol-name x) 0) #\&))
+				    x
+				    'single-float))
+			      args))
+	(ease-in (alexandria:symbolicate 'ease-in- name :-f))
+	(ease-out (alexandria:symbolicate 'ease-out- name :-f))
+	(ease-in-out (alexandria:symbolicate 'ease-in-out- name :-f)))
+    `(progn
+       ;; in
+       (declaim (inline ,ease-in)
+		(ftype (function ,declaim-args single-float) ,ease-in))
+       (defun ,ease-in ,args
+	 (declare (optimize (speed 3) (safety 0) (debug 0))
+		  (single-float ,@arg-names)
+		  (inline + - / *))
+	 (cond ((>= 0s0 ,x) 0s0)
+	       ((<= 1s0 ,x) 1s0)
+	       (t ,@body)))
+       ;; out
+       (declaim (inline ,ease-out)
+		(ftype (function ,declaim-args single-float) ,ease-out))
+       (defun ,ease-out ,args
+	 (declare (optimize (speed 3) (safety 0) (debug 0))
+		  (single-float ,@arg-names)
+		  (inline + - / *))
+	 (cond ((>= 0s0 ,x) 0s0)
+	       ((<= 1s0 ,x) 1s0)
+	       (t (let ((,x (- 1s0 ,x)))
+		    (the single-float
+			 (+ 1s0 (- ,@body)))))))
+       ;; in-out
+       (declaim (inline ,ease-in-out)
+		(ftype (function ,declaim-args single-float) ,ease-in-out))
+       (defun ,ease-in-out ,args
+	 (declare (optimize (speed 3) (safety 0) (debug 0))
+		  (single-float ,@arg-names)
+		  (inline + - / *))
+	 (cond ((>= 0s0 ,x) 0s0)
+	       ((<= 1s0 ,x) 1s0)
+	       (t (the single-float
+		       (if (<= ,x 0.5s0)
+			   (let ((,x (* 2s0 ,x)))
+			     (/ ,@body 2s0))
+			   (let ((,x (- 1s0 (* 2s0 (- ,x 0.5s0)))))
+			     (+ 0.5s0 (/ (+ 1s0 (- ,@body))
+					 2s0)))))))))))
+
+;; The float versions
+
+(declaim (inline linear-f)
+         (ftype (function (single-float) single-float) linear-f))
+(defun linear-f (x)
+  (declare (optimize (speed 3) (safety 0) (debug 0))
+	   (single-float x))
+  x)
+
+(defeasing-f sine (x)
+  (- 1s0 (cos (* x (/ pi-sf 2s0)))))
+
+(defeasing-f quad (x)
+  (* x x))
+
+(defeasing-f cubic (x)
+  (* x x x))
+
+(defeasing-f quart (x)
+  (expt x 4s0))
+
+(defeasing-f quint (x)
+  (expt x 5s0))
+
+(defeasing-f exp (x)
+  (expt 2s0 (* 10s0 (- x 1s0))))
+
+(defeasing-f circ (x)
+  (- (- (the single-float (sqrt (- 1s0 (* x x)))) 1s0)))
+
+(defeasing-f elastic (x &optional (p 0.3s0) (s 0s0 set-s))
+  (let ((s (if set-s s (* (asin 1s0) (* p #.(/ 1s0 (* 2s0 pi-sf)))))))
+    (- (* (expt 2 (* 10 (- x 1s0))) (sin (/ (* (- (- x 1s0) s) (* 2 pi-sf)) p))))))
+
+(defeasing-f back (x &optional (s 1.70158s0))
+  (* x x (- (* (+ 1s0 s) x) s)))
+
+(defeasing-f bounce (x &optional (c1 7.5625))
+  (let ((x (- 1s0 x)))
+    (- 1s0 (cond ((< x (/ 1s0 2.75)) (* c1 x x))
+		 ((< x (/ 2s0 2.75s0)) (let ((x (- x (/ 1.5s0 2.75s0))))
+					 (+ 0.75s0 (* c1 x x))))
+		 ((< x (/ 2.5s0 2.75s0)) (let ((x (- x (/ 2.25 2.75))))
+					   (+ 0.9375s0 (* c1 x x))))
+		 (t (let ((x (- x (/ 2.625s0 2.75s0))))
+		      (+ 0.984375s0 (* c1 x x))))))))

--- a/easing.asd
+++ b/easing.asd
@@ -7,5 +7,5 @@
   :depends-on (#:alexandria)
   :serial t
   :components ((:file "package")
-               (:file "easing")))
-
+               (:file "easing")
+	       (:file "easing-single-float")))

--- a/easing.lisp
+++ b/easing.lisp
@@ -5,16 +5,16 @@
 (defmacro defeasing (name args &body body)
   (let ((x (or (car args) 'x)))
     `(progn
-       (defun ,(alexandria:symbolicate 'ease-in- name) ,args
+       (defun ,(alexandria:symbolicate 'in- name) ,args
 	 (cond ((>= 0 ,x) 0)
 	       ((<= 1 ,x) 1)
 	       (t ,@body)))
-       (defun ,(alexandria:symbolicate 'ease-out- name) ,args
+       (defun ,(alexandria:symbolicate 'out- name) ,args
 	 (cond ((>= 0 ,x) 0)
 	       ((<= 1 ,x) 1)
 	       (t (let ((,x (- 1 ,x)))
 		    (1+ (- ,@body))))))
-       (defun ,(alexandria:symbolicate 'ease-in-out- name) ,args
+       (defun ,(alexandria:symbolicate 'in-out- name) ,args
 	 (cond ((>= 0 ,x) 0)
 	       ((<= 1 ,x) 1)
 	       (t (if (<= ,x 0.5)

--- a/package.lisp
+++ b/package.lisp
@@ -13,3 +13,17 @@
 	   :ease-in-elastic :ease-out-elastic :ease-in-out-elastic
 	   :ease-in-back :ease-out-back :ease-in-out-back
 	   :ease-in-bounce :ease-out-bounce :ease-in-out-bounce))
+
+(defpackage #:easing-single-float
+  (:use #:cl)
+  (:export :defeasing-f :linear-f
+	   :ease-in-sine-f :ease-out-sine-f :ease-in-out-sine-f
+	   :ease-in-cubic-f :ease-out-cubic-f :ease-in-out-cubic-f
+	   :ease-in-quad-f :ease-out-quad-f :ease-in-out-quad-f
+	   :ease-in-quart-f :ease-out-quart-f :ease-in-out-quart-f
+	   :ease-in-quint-f :ease-out-quint-f :ease-in-out-quint-f
+	   :ease-in-exp-f :ease-out-exp-f :ease-in-out-exp-f
+	   :ease-in-circ-f :ease-out-circ-f :ease-in-out-circ-f
+	   :ease-in-elastic-f :ease-out-elastic-f :ease-in-out-elastic-f
+	   :ease-in-back-f :ease-out-back-f :ease-in-out-back-f
+	   :ease-in-bounce-f :ease-out-bounce-f :ease-in-out-bounce-f))

--- a/package.lisp
+++ b/package.lisp
@@ -3,27 +3,27 @@
 (defpackage #:easing
   (:use #:cl)
   (:export :defeasing :linear
-	   :ease-in-sine :ease-out-sine :ease-in-out-sine
-	   :ease-in-cubic :ease-out-cubic :ease-in-out-cubic
-	   :ease-in-quad :ease-out-quad :ease-in-out-quad
-	   :ease-in-quart :ease-out-quart :ease-in-out-quart
-	   :ease-in-quint :ease-out-quint :ease-in-out-quint
-	   :ease-in-exp :ease-out-exp :ease-in-out-exp
-	   :ease-in-circ :ease-out-circ :ease-in-out-circ
-	   :ease-in-elastic :ease-out-elastic :ease-in-out-elastic
-	   :ease-in-back :ease-out-back :ease-in-out-back
-	   :ease-in-bounce :ease-out-bounce :ease-in-out-bounce))
+	   :in-sine :out-sine :in-out-sine
+	   :in-cubic :out-cubic :in-out-cubic
+	   :in-quad :out-quad :in-out-quad
+	   :in-quart :out-quart :in-out-quart
+	   :in-quint :out-quint :in-out-quint
+	   :in-exp :out-exp :in-out-exp
+	   :in-circ :out-circ :in-out-circ
+	   :in-elastic :out-elastic :in-out-elastic
+	   :in-back :out-back :in-out-back
+	   :in-bounce :out-bounce :in-out-bounce))
 
-(defpackage #:easing-single-float
+(defpackage #:easing-f
   (:use #:cl)
-  (:export :defeasing-f :linear-f
-	   :ease-in-sine-f :ease-out-sine-f :ease-in-out-sine-f
-	   :ease-in-cubic-f :ease-out-cubic-f :ease-in-out-cubic-f
-	   :ease-in-quad-f :ease-out-quad-f :ease-in-out-quad-f
-	   :ease-in-quart-f :ease-out-quart-f :ease-in-out-quart-f
-	   :ease-in-quint-f :ease-out-quint-f :ease-in-out-quint-f
-	   :ease-in-exp-f :ease-out-exp-f :ease-in-out-exp-f
-	   :ease-in-circ-f :ease-out-circ-f :ease-in-out-circ-f
-	   :ease-in-elastic-f :ease-out-elastic-f :ease-in-out-elastic-f
-	   :ease-in-back-f :ease-out-back-f :ease-in-out-back-f
-	   :ease-in-bounce-f :ease-out-bounce-f :ease-in-out-bounce-f))
+  (:export :defeasing :linear
+	   :in-sine :out-sine :in-out-sine
+	   :in-cubic :out-cubic :in-out-cubic
+	   :in-quad :out-quad :in-out-quad
+	   :in-quart :out-quart :in-out-quart
+	   :in-quint :out-quint :in-out-quint
+	   :in-exp :out-exp :in-out-exp
+	   :in-circ :out-circ :in-out-circ
+	   :in-elastic :out-elastic :in-out-elastic
+	   :in-back :out-back :in-out-back
+	   :in-bounce :out-bounce :in-out-bounce))


### PR DESCRIPTION
This is a personal preference thing but for simple maths functions I prefer to use an API that you don't `:use` in your package. Instead you reference directly using the package name.

This means you don't add a pile of symbols to your package and you can use shorter names (as they won't collide)

For example:

```
   CL-USER> (easing:in-cubic 0.3)
   0.027000003
   CL-USER> (easing-f:in-cubic 0.3)
   0.027000003
```
